### PR TITLE
Add support for context

### DIFF
--- a/navvy_test.go
+++ b/navvy_test.go
@@ -1,6 +1,7 @@
 package navvy
 
 import (
+	"context"
 	"log"
 	"testing"
 	"time"
@@ -10,7 +11,11 @@ type sleepTask struct {
 	id int
 }
 
-func (st *sleepTask) Run() {
+func (st *sleepTask) Context() context.Context {
+	return nil
+}
+
+func (st *sleepTask) Run(_ context.Context) {
 	log.Printf("Task %d start", st.id)
 	time.Sleep(time.Second)
 	log.Printf("Task %d finished", st.id)

--- a/task.go
+++ b/task.go
@@ -1,19 +1,33 @@
 package navvy
 
+import "context"
+
 // Task is the acceptable input for navvy.
 type Task interface {
-	Run()
+	Context() context.Context // Context used to get context if no ctx passed when run
+	Run(ctx context.Context)
 }
 
 type taskWithFunc struct {
-	fn func()
+	ctx context.Context
+	fn  func(ctx context.Context)
 }
 
-func (t *taskWithFunc) Run() {
-	t.fn()
+func (t *taskWithFunc) Run(ctx context.Context) {
+	if ctx == nil {
+		ctx = t.Context()
+	}
+	t.fn(ctx)
+}
+
+func (t *taskWithFunc) Context() context.Context {
+	if t.ctx == nil {
+		return context.Background()
+	}
+	return t.ctx
 }
 
 // TaskWrapper will wrapper a func into a valid task.
-func TaskWrapper(fn func()) Task {
-	return &taskWithFunc{fn}
+func TaskWrapper(fn func(ctx context.Context)) Task {
+	return &taskWithFunc{nil, fn}
 }

--- a/worker.go
+++ b/worker.go
@@ -41,7 +41,7 @@ func (w *Worker) run() {
 				return
 			}
 
-			f.Run()
+			f.Run(f.Context())
 			w.pool.wg.Done()
 
 			if ok := w.pool.revertWorker(w); !ok {


### PR DESCRIPTION
When get task from chan, run it with context by calling `Context()` method.